### PR TITLE
changing estimation methods for fastglm and parglm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Doubly Robust Difference-in-Differences Estimators
 Version: 1.0.8.902
 Authors@R: c(person("Pedro H. C.", "Sant'Anna", email = "pedrosantanna@causal-solutions.com",
-              role = c("aut", "cre")),
+              role = c("aut", "cre", "cph")),
               person("Jun", "Zhao", email = "beanzhaojun11@gmail.com",role = c("aut"))
             )
 Description: Implements the locally efficient doubly robust difference-in-differences (DiD)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DRDID
 Type: Package
 Title: Doubly Robust Difference-in-Differences Estimators
-Version: 1.0.7
+Version: 1.0.8.902
 Authors@R: c(person("Pedro H. C.", "Sant'Anna", email = "pedrosantanna@causal-solutions.com",
               role = c("aut", "cre")),
               person("Jun", "Zhao", email = "beanzhaojun11@gmail.com",role = c("aut"))
@@ -34,6 +34,6 @@ Suggests:
     rmarkdown,
     spelling,
     testthat
-Date: 2025-07-5
+Date: 2025-08-21
 Language: en-US
 BugReports: https://github.com/pedrohcgs/DRDID/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,9 @@ Imports:
     stats,
     trust,
     BMisc (>= 1.4.1),
-    Rcpp (>= 1.0.12)
+    Rcpp (>= 1.0.12),
+    parglm (>= 0.1.7),
+    fastglm (>= 0.0.3)
 LinkingTo: 
     Rcpp (>= 1.0.12)
 RoxygenNote: 7.3.1

--- a/R/drdid_panel.R
+++ b/R/drdid_panel.R
@@ -97,7 +97,7 @@ drdid_panel <-function(y1, y0, D, covariates, i.weights = NULL,
   #-----------------------------------------------------------------------------
   #Compute the Pscore by MLE
   #pscore.tr <- stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights)
-  pscore.tr <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
+  pscore.tr <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
   if(pscore.tr$converged == FALSE){
     warning(" glm algorithm did not converge")
   }

--- a/R/drdid_rc.R
+++ b/R/drdid_rc.R
@@ -91,7 +91,7 @@ drdid_rc <-function(y, post, D, covariates, i.weights = NULL,
   #-----------------------------------------------------------------------------
   #Compute the Pscore by MLE
   #pscore.tr <- stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights)
-  pscore.tr <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
+  pscore.tr <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
   if(pscore.tr$converged == FALSE){
     warning(" glm algorithm did not converge")
   }

--- a/R/drdid_rc.R
+++ b/R/drdid_rc.R
@@ -90,7 +90,8 @@ drdid_rc <-function(y, post, D, covariates, i.weights = NULL,
   i.weights <- i.weights/mean(i.weights)
   #-----------------------------------------------------------------------------
   #Compute the Pscore by MLE
-  pscore.tr <- stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights)
+  #pscore.tr <- stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights)
+  pscore.tr <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
   if(pscore.tr$converged == FALSE){
     warning(" glm algorithm did not converge")
   }
@@ -101,17 +102,32 @@ drdid_rc <-function(y, post, D, covariates, i.weights = NULL,
   # Avoid divide by zero
   ps.fit <- pmin(ps.fit, 1 - 1e-16)
   #Compute the Outcome regression for the control group at the pre-treatment period, using ols.
-  reg.cont.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                              subset = ((D==0) & (post==0)),
-                                              weights = i.weights))
+  # reg.cont.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                             subset = ((D==0) & (post==0)),
+  #                                             weights = i.weights))
+  pre_filter <- (D == 0) & (post == 0)
+  reg.cont.coeff.pre <- stats::coef(fastglm::fastglm(
+                                    x = int.cov[pre_filter, , drop = FALSE],
+                                    y = y[pre_filter],
+                                    weights = i.weights[pre_filter],
+                                    family = gaussian(link = "identity")
+  ))
   if(anyNA(reg.cont.coeff.pre)){
     stop("Outcome regression model coefficients have NA components. \n Multicollinearity (or lack of variation) of covariates is a likely reason.")
   }
   out.y.cont.pre <-   as.vector(tcrossprod(reg.cont.coeff.pre, int.cov))
   #Compute the Outcome regression for the control group at the post-treatment period, using ols.
-  reg.cont.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                               subset = ((D==0) & (post==1)),
-                                               weights = i.weights))
+  # reg.cont.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                              subset = ((D==0) & (post==1)),
+  #                                              weights = i.weights))
+
+  post_filter <- (D == 0) & (post == 1)
+  reg.cont.coeff.post <- stats::coef(fastglm::fastglm(
+                                      x = int.cov[post_filter, , drop = FALSE],
+                                      y = y[post_filter],
+                                      weights = i.weights[post_filter],
+                                      family = gaussian(link = "identity")
+  ))
   if(anyNA(reg.cont.coeff.post)){
     stop("Outcome regression model coefficients have NA components. \n Multicollinearity (or lack of variation) of covariates is a likely reason.")
   }
@@ -121,14 +137,28 @@ drdid_rc <-function(y, post, D, covariates, i.weights = NULL,
 
 
   #Compute the Outcome regression for the treated group at the pre-treatment period, using ols.
-  reg.treat.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                               subset = ((D==1) & (post==0)),
-                                               weights = i.weights))
+  # reg.treat.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                              subset = ((D==1) & (post==0)),
+  #                                              weights = i.weights))
+  pre_treat_filter <- (D == 1) & (post == 0)
+  reg.treat.coeff.pre <- stats::coef(fastglm::fastglm(
+                              x = int.cov[pre_treat_filter, , drop = FALSE],
+                              y = y[pre_treat_filter],
+                              weights = i.weights[pre_treat_filter],
+                              family = gaussian(link = "identity")
+  ))
   out.y.treat.pre <-   as.vector(tcrossprod(reg.treat.coeff.pre, int.cov))
   #Compute the Outcome regression for the treated group at the post-treatment period, using ols.
-  reg.treat.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                                subset = ((D==1) & (post==1)),
-                                                weights = i.weights))
+  # reg.treat.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                               subset = ((D==1) & (post==1)),
+  #                                               weights = i.weights))
+  post_treat_filter <- (D == 1) & (post == 1)
+  reg.treat.coeff.post <- stats::coef(fastglm::fastglm(
+                                      x = int.cov[post_treat_filter, , drop = FALSE],
+                                      y = y[post_treat_filter],
+                                      weights = i.weights[post_treat_filter],
+                                      family = gaussian(link = "identity")
+  ))
   out.y.treat.post <-   as.vector(tcrossprod(reg.treat.coeff.post, int.cov))
 
 

--- a/R/reg_did_panel.R
+++ b/R/reg_did_panel.R
@@ -99,9 +99,16 @@ reg_did_panel <-function(y1, y0, D, covariates, i.weights = NULL,
   i.weights <- i.weights/mean(i.weights)
   #-----------------------------------------------------------------------------
   #Compute the Outcome regression for the control group using ols.
-  reg.coeff <- stats::coef(stats::lm(deltaY ~ -1 + int.cov,
-                                     subset = D==0,
-                                     weights = i.weights))
+  # reg.coeff <- stats::coef(stats::lm(deltaY ~ -1 + int.cov,
+  #                                    subset = D==0,
+  #                                    weights = i.weights))
+  control_filter <- (D == 0)
+  reg.coeff <- stats::coef(fastglm::fastglm(
+                            x = int.cov[control_filter, , drop = FALSE],
+                            y = deltaY[control_filter],
+                            weights = i.weights[control_filter],
+                            family = gaussian(link = "identity")
+  ))
   if(anyNA(reg.coeff)){
     stop("Outcome regression model coefficients have NA components. \n Multicollinearity (or lack of variation) of covariates is probably the reason for it.")
   }

--- a/R/reg_did_rc.R
+++ b/R/reg_did_rc.R
@@ -89,18 +89,33 @@ reg_did_rc <-function(y, post, D, covariates, i.weights = NULL,
 
   #-----------------------------------------------------------------------------
   #Compute the Outcome regression for the control group at the pre-treatment period, using ols.
-  reg.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                         subset = ((D==0) & (post==0)),
-                                         weights = i.weights))
+  # reg.coeff.pre <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                        subset = ((D==0) & (post==0)),
+  #                                        weights = i.weights))
+
+  pre_filter <- (D == 0) & (post == 0)
+  reg.coeff.pre <- stats::coef(fastglm::fastglm(
+                        x = int.cov[pre_filter, , drop = FALSE],
+                        y = y[pre_filter],
+                        weights = i.weights[pre_filter],
+                        family = gaussian(link = "identity")
+  ))
   if(anyNA(reg.coeff.pre)){
     stop("Outcome regression model coefficients have NA components. \n Multicollinearity of covariates is probably the reason for it.")
   }
   out.y.pre <-   as.vector(tcrossprod(reg.coeff.pre, int.cov))
   #-----------------------------------------------------------------------------
   #Compute the Outcome regression for the control group at the pre-treatment period, using ols.
-  reg.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
-                                          subset = ((D==0) & (post==1)),
-                                          weights = i.weights))
+  # reg.coeff.post <- stats::coef(stats::lm(y ~ -1 + int.cov,
+  #                                         subset = ((D==0) & (post==1)),
+  #                                         weights = i.weights))
+  post_filter <- (D == 0) & (post == 1)
+  reg.coeff.post <- stats::coef(fastglm::fastglm(
+                          x = int.cov[post_filter, , drop = FALSE],
+                          y = y[post_filter],
+                          weights = i.weights[post_filter],
+                          family = gaussian(link = "identity")
+  ))
   if(anyNA(reg.coeff.post)){
     stop("Outcome regression model coefficients have NA components. \n Multicollinearity (or lack of variation) of covariates is probably the reason for it.")
   }

--- a/R/std_ipw_did_panel.R
+++ b/R/std_ipw_did_panel.R
@@ -89,7 +89,7 @@ std_ipw_did_panel <-function(y1, y0, D, covariates, i.weights = NULL,
   #-----------------------------------------------------------------------------
   #Pscore estimation (logit) and also its fitted values
   #PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
-  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
+  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
   ps.fit <- as.vector(PS$fitted.values)
   # Do not divide by zero
   ps.fit <- pmin(ps.fit, 1 - 1e-16)

--- a/R/std_ipw_did_panel.R
+++ b/R/std_ipw_did_panel.R
@@ -88,7 +88,8 @@ std_ipw_did_panel <-function(y1, y0, D, covariates, i.weights = NULL,
   i.weights <- i.weights/mean(i.weights)
   #-----------------------------------------------------------------------------
   #Pscore estimation (logit) and also its fitted values
-  PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
+  #PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
+  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
   ps.fit <- as.vector(PS$fitted.values)
   # Do not divide by zero
   ps.fit <- pmin(ps.fit, 1 - 1e-16)

--- a/R/std_ipw_did_rc.R
+++ b/R/std_ipw_did_rc.R
@@ -81,7 +81,8 @@ std_ipw_did_rc <-function(y, post, D, covariates, i.weights = NULL,
   i.weights <- i.weights/mean(i.weights)
   #-----------------------------------------------------------------------------
   #Pscore estimation (logit) and also its fitted values
-  PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
+  #PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
+  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
   ps.fit <- as.vector(PS$fitted.values)
   # Do not divide by zero
   ps.fit <- pmin(ps.fit, 1 - 1e-16)

--- a/R/std_ipw_did_rc.R
+++ b/R/std_ipw_did_rc.R
@@ -82,7 +82,7 @@ std_ipw_did_rc <-function(y, post, D, covariates, i.weights = NULL,
   #-----------------------------------------------------------------------------
   #Pscore estimation (logit) and also its fitted values
   #PS <- suppressWarnings(stats::glm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
-  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights, nthreads = (parallel::detectCores() - 1)))
+  PS <- suppressWarnings(parglm::parglm(D ~ -1 + int.cov, family = "binomial", weights = i.weights))
   ps.fit <- as.vector(PS$fitted.values)
   # Do not divide by zero
   ps.fit <- pmin(ps.fit, 1 - 1e-16)


### PR DESCRIPTION
I'm switching the glm backend to faster solutions: fastglm and parglm.
🚨 These changes affect `did` too 🚨

Changes:

- std_ipw_did_panel; line 91, glm for parglm
- reg_did_panel; line 102, lm for fastglm
- drdid_panel; line 99 and 110, parglm and fastglm respectively
- std_ipw_did_rc; line 84, glm for parglm
- reg_did_rc; line 92 and 101, fastglm
- drdid_rc; line 93, 104, 112, 124, 129

These changes affect estimation procedures. Passing all unit tests. 

![image](https://github.com/user-attachments/assets/fb1d7424-43a7-4285-917d-71eeabc41829)
