### PR TITLE
Replace deprecated BMisc function names in pre_process_drdid.R

### DIFF
--- a/R/pre_process_drdid.R
+++ b/R/pre_process_drdid.R
@@ -155,7 +155,7 @@ pre_process_drdid <- function(yname,
 
   # If panel, make it a balanced data set
   if (panel) {
-    dta <- BMisc::makeBalancedPanel(dta, idname, tname)
+    dta <- BMisc::make_balanced_panel(dta, idname, tname)
   }
 
 
@@ -203,7 +203,7 @@ pre_process_drdid <- function(yname,
 
   # how many in each group before give warning
   # 5 is just a buffer, could pick something else, but seems to work fine
-  reqsize <- length(BMisc::rhs.vars(xformla)) + 5
+  reqsize <- length(BMisc::rhs_vars(xformla)) + 5
 
   # which groups to warn about
   gsize <- subset(gsize,
@@ -217,7 +217,7 @@ pre_process_drdid <- function(yname,
   # setup data in panel case
   if (panel) {
     # make it a balanced data set
-    dta <- BMisc::makeBalancedPanel(dta, idname, tname)
+    dta <- BMisc::make_balanced_panel(dta, idname, tname)
 
     # Only use this smaller dataset
     dta <- as.data.frame(cbind(y = dta$y,


### PR DESCRIPTION
## Summary

The `BMisc` package is deprecating its old camelCase/dot-separated function names in favour of snake_case equivalents, with planned removal in an upcoming release. This PR updates the three affected call sites in `R/pre_process_drdid.R`:

- `BMisc::makeBalancedPanel()` → `BMisc::make_balanced_panel()` (2 calls, lines 158 and 220)
- `BMisc::rhs.vars()` → `BMisc::rhs_vars()` (1 call, line 206)

The commented-out reference to `BMisc::rhs.vars` on line 88 is left as-is since it is not executed.

## Test plan

- [ ] `devtools::check()` passes with 0 errors, 0 warnings (confirmed locally against DRDID 1.2.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)